### PR TITLE
Simplify documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Add translation to `resources/lang/en/validation.php`
 ## Usage
 
 ```php
-    $emailInput = $request->validate([
-        'email' => 'required|email|neverbounce',
-    ]);
+$emailInput = $request->validate([
+    'email' => 'required|email|neverbounce',
+]);
 ```

--- a/README.md
+++ b/README.md
@@ -1,39 +1,19 @@
 # laravel-neverbounce
 
-A laravel wrapper for the [NeverBounceAPI-PHP](https://github.com/NeverBounce/NeverBounceAPI-PHP).
-
-Extends Laravel Validator to check a single email address against the NeverBounce API.
-
-The Neverbounce API allows up to [1,000 free email verifications](https://neverbounce.com/help/getting-started/how-do-the-1000-free-credits-work) per month.
-
----
+Validate an email address against the [NeverBounce API](https://neverbounce.com).
 
 ## Installation
-
-Within your Terminal:
 
 ```bash
 composer require moonbaselabs/laravel-neverbounce
 ```
 
-Add configuration values to `configs/services.php`:
+Add API key to `configs/services.php` (See [Obtaining an API Key](#obtaining-an-api-key) below):
 
 ```php
     'neverbounce' => [
         'api_key' => env('NEVERBOUNCE_API_KEY'),
     ],
-```
-
-**Obtain Neverbounce API Key:**
-
-1. [Register]("https://app.neverbounce.com/register") for a Neverbounce Account.
-2. Create a new App.
-3. Copy secret API Key. (Note: Make sure it is a v4 api key. It will start with `private_***`).
-
-Add Neverbounce API Key to `.env`:
-
-```php
-NEVERBOUNCE_API_KEY=private_key
 ```
 
 Add translation to `resources/lang/en/validation.php`
@@ -42,9 +22,13 @@ Add translation to `resources/lang/en/validation.php`
     'neverbounce' => 'The :attribute is not valid. :suggestion :error',
 ```
 
----
+### Obtaining an API key
 
-## Useage
+1. [Register]("https://app.neverbounce.com/register") for a Neverbounce Account.
+2. Create a new App.
+3. Copy secret API Key. (Note: Make sure it is a v4 api key. It will start with `private_***`).
+
+## Usage
 
 ```php
     $emailInput = $request->validate([

--- a/README.md
+++ b/README.md
@@ -11,15 +11,15 @@ composer require moonbaselabs/laravel-neverbounce
 Add API key to `configs/services.php` (See [Obtaining an API Key](#obtaining-an-api-key) below):
 
 ```php
-    'neverbounce' => [
-        'api_key' => env('NEVERBOUNCE_API_KEY'),
-    ],
+'neverbounce' => [
+    'api_key' => env('NEVERBOUNCE_API_KEY'),
+],
 ```
 
 Add translation to `resources/lang/en/validation.php`
 
 ```php
-    'neverbounce' => 'The :attribute is not valid. :suggestion :error',
+'neverbounce' => 'The :attribute is not valid. :suggestion :error',
 ```
 
 ### Obtaining an API key


### PR DESCRIPTION
 - The 1,000 emails doesn't seem worth mentioning since a credit card is required anyway.
 - Moved the Obtaining an API Key info to it's own sections, since some users may already have a key and just want to see the installation steps.
 - Removed extraneous formatting, just to keep the markdown simple.
 - I removed indentation in the code since Laravel's docs don't assume indentation.
 - Fixed typos